### PR TITLE
Add try/catch code to handle exceptions

### DIFF
--- a/ublox_gps/src/node_main.cpp
+++ b/ublox_gps/src/node_main.cpp
@@ -10,9 +10,15 @@ int main(int argc, char** argv) {
 
   rclcpp::init(argc, argv);
 
-  rclcpp::spin(std::make_shared<ublox_node::UbloxNode>(rclcpp::NodeOptions()));
+  int exit_code = 0;
+  try {
+    rclcpp::spin(std::make_shared<ublox_node::UbloxNode>(rclcpp::NodeOptions()));
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(rclcpp::get_logger("ublox_gps_node"), "Fatal error: %s", e.what());
+    exit_code = 1;
+  }
 
   rclcpp::shutdown();
 
-  return 0;
+  return exit_code;
 }


### PR DESCRIPTION
## なんのための変更？

* ノードがクラッシュするとDDS通信の生存情報を汚すため修正します
* 起動してノードのdiscoverに登録したあと居なくなったことを通知しないので名前空間が汚れていました
* discoverが通信帯域を食いつぶすとBest effortのカメラがコマ落ちします

## やったこと

* rclcpp::shutdown()を呼んで居なくなったことを喋ってから落ちるように修正

## やらないこと

* 特になし

## 影響範囲

* 無応答discoverが大量にばらまかれて通信負荷がかかる問題が解消される

## 動作確認

* 実機で死んだノード登録が残らないことを確認

## 悩んでいるところ、とくにレビューしてほしいところ

* DDS の生存時間を別途調整した方がいいかも
